### PR TITLE
perf: SIMD-friendly SOA extraction for auto-vectorized reductions

### DIFF
--- a/mordred-core/Cargo.toml
+++ b/mordred-core/Cargo.toml
@@ -6,6 +6,10 @@ rust-version.workspace = true
 license.workspace = true
 description = "Core molecular descriptor calculator — Rust port of mordred"
 
+[features]
+default = []
+simd = []
+
 [dependencies]
 petgraph = { workspace = true }
 nalgebra = { workspace = true }

--- a/mordred-core/src/molecule/mod.rs
+++ b/mordred-core/src/molecule/mod.rs
@@ -11,6 +11,7 @@ pub mod bond;
 pub mod element;
 pub mod mol;
 pub mod rings;
+pub mod simd;
 pub mod smiles;
 
 pub use aromaticity::perceive_aromaticity;

--- a/mordred-core/src/molecule/mol.rs
+++ b/mordred-core/src/molecule/mol.rs
@@ -173,44 +173,39 @@ impl Molecule {
         self.properties().element_counts[element.discriminant_index()] as usize
     }
 
-    /// Cached molecular properties computed in two passes (1 atom, 1 bond).
+    /// Cached molecular properties computed via SOA extraction + vectorized reductions.
+    ///
+    /// Extracts element discriminants, implicit H values, and masses into
+    /// contiguous arrays, then processes them with tight loops that LLVM
+    /// can auto-vectorize.
     pub fn properties(&self) -> &MolecularProperties {
         self.props_cache.get_or_init(|| {
-            let mut element_counts = [0u32; 26];
-            let mut heavy_atom_count = 0u32;
-            let mut implicit_h_sum = 0u32;
-            let mut molecular_weight = 0.0f64;
-            let mut halogen_count = 0u32;
-            let mut heteroatom_count = 0u32;
             let node_count = self.graph.node_count();
+
+            // SOA extraction: pull fields into contiguous arrays for auto-vectorization
+            let mut discriminants = Vec::with_capacity(node_count);
+            let mut implicit_h_values = Vec::with_capacity(node_count);
+            let mut masses = Vec::with_capacity(node_count);
             let mut degrees = vec![0u32; node_count];
 
-            // Atom pass
             for idx in self.graph.node_indices() {
                 let atom = &self.graph[idx];
-                let elem = atom.element;
-                element_counts[elem.discriminant_index()] += 1;
-                implicit_h_sum += atom.implicit_h as u32;
-                molecular_weight += atom.exact_mass();
-
-                if elem.is_heavy() {
-                    heavy_atom_count += 1;
-                }
-                if matches!(elem, Element::F | Element::Cl | Element::Br | Element::I) {
-                    halogen_count += 1;
-                }
-                if elem != Element::C && elem != Element::H {
-                    heteroatom_count += 1;
-                }
-
-                // Compute degree (explicit bonds)
+                discriminants.push(atom.element.discriminant_index() as u8);
+                implicit_h_values.push(atom.implicit_h);
+                masses.push(atom.exact_mass());
                 degrees[idx.index()] = self.graph.neighbors(idx).count() as u32;
             }
 
-            // explicit H atoms + all implicit H
+            // Vectorized reductions over contiguous arrays
+            let element_counts = super::simd::element_histogram(&discriminants);
+            let implicit_h_sum = super::simd::sum_implicit_h(&implicit_h_values);
+            let molecular_weight = super::simd::sum_molecular_weight(&masses);
+            let heavy_atom_count = super::simd::count_heavy(&discriminants);
+            let halogen_count = super::simd::count_halogens(&discriminants);
+            let heteroatom_count = super::simd::count_heteroatoms(&discriminants);
+
             let hydrogen_count = element_counts[Element::H.discriminant_index()]
                 + implicit_h_sum;
-
             let total_atom_count = node_count as u32 + implicit_h_sum;
 
             // Bond pass

--- a/mordred-core/src/molecule/simd.rs
+++ b/mordred-core/src/molecule/simd.rs
@@ -1,0 +1,72 @@
+/// SIMD-friendly molecular property computation.
+///
+/// Provides functions that extract SOA (Structure of Arrays) data from
+/// a molecule's graph to enable LLVM auto-vectorization of reductions.
+///
+/// On stable Rust, element discriminants are extracted to a contiguous
+/// `Vec<u8>` and processed with tight loops that LLVM can auto-vectorize.
+///
+/// On nightly Rust with `--features simd`, explicit `std::simd` intrinsics
+/// are used for wider vectorization (not yet implemented — reserved for
+/// future nightly builds).
+use super::element::Element;
+
+/// Build element histogram from a contiguous array of discriminant indices.
+///
+/// This is structured as a tight loop over a contiguous u8 slice,
+/// which LLVM can optimize better than scattered graph accesses.
+#[inline]
+pub fn element_histogram(discriminants: &[u8]) -> [u32; 26] {
+    let mut counts = [0u32; 26];
+    for &d in discriminants {
+        counts[d as usize] += 1;
+    }
+    counts
+}
+
+/// Sum implicit hydrogen values from a contiguous array.
+///
+/// Tight u8→u32 reduction loop for auto-vectorization.
+#[inline]
+pub fn sum_implicit_h(implicit_h_values: &[u8]) -> u32 {
+    implicit_h_values.iter().map(|&h| h as u32).sum()
+}
+
+/// Accumulate molecular weight from contiguous mass values.
+///
+/// f64 accumulation in a tight loop enables LLVM to use SIMD FP adds.
+#[inline]
+pub fn sum_molecular_weight(masses: &[f64]) -> f64 {
+    masses.iter().sum()
+}
+
+/// Count heavy atoms (non-hydrogen) from discriminant array.
+#[inline]
+pub fn count_heavy(discriminants: &[u8]) -> u32 {
+    let h_idx = Element::H.discriminant_index() as u8;
+    discriminants.iter().filter(|&&d| d != h_idx).count() as u32
+}
+
+/// Count halogens from discriminant array.
+#[inline]
+pub fn count_halogens(discriminants: &[u8]) -> u32 {
+    let f_idx = Element::F.discriminant_index() as u8;
+    let cl_idx = Element::Cl.discriminant_index() as u8;
+    let br_idx = Element::Br.discriminant_index() as u8;
+    let i_idx = Element::I.discriminant_index() as u8;
+    discriminants
+        .iter()
+        .filter(|&&d| d == f_idx || d == cl_idx || d == br_idx || d == i_idx)
+        .count() as u32
+}
+
+/// Count heteroatoms (non-C, non-H) from discriminant array.
+#[inline]
+pub fn count_heteroatoms(discriminants: &[u8]) -> u32 {
+    let c_idx = Element::C.discriminant_index() as u8;
+    let h_idx = Element::H.discriminant_index() as u8;
+    discriminants
+        .iter()
+        .filter(|&&d| d != c_idx && d != h_idx)
+        .count() as u32
+}


### PR DESCRIPTION
## Summary
- Extract element discriminants, implicit H, and masses into contiguous `Vec<u8>`/`Vec<f64>` arrays
- Process with tight loops that LLVM can auto-vectorize (histogram, sum, count)
- Add `simd` feature flag (reserved for future nightly `std::simd` intrinsics)
- New module: `mordred-core/src/molecule/simd.rs`

**Depends on:** PR #27 (fused counting / `MolecularProperties`)

## Expected performance
1.5-2x for large molecules via LLVM auto-vectorization, marginal for small molecules.

## Test plan
- [x] `cargo test --workspace --exclude mordred-py` — 92 tests pass
- [x] `cargo test -p mordred-core --features simd` — passes
- [x] `cargo clippy --workspace --exclude mordred-py` — clean
- [ ] `cargo run --release --example bench` — compare before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)